### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/chrisreddington/gh-demo/security/code-scanning/1](https://github.com/chrisreddington/gh-demo/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the tasks in the workflow, the minimal required permission is `contents: read`, as the workflow only needs to read the repository contents to build, test, and lint the code. No write permissions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
